### PR TITLE
Compile warnings

### DIFF
--- a/lib/compileContracts.js
+++ b/lib/compileContracts.js
@@ -1,4 +1,5 @@
 import solc from 'solc'
+import chalk from 'chalk'
 import arrayToObject from './util/arrayToObject.js'
 
 /**
@@ -18,7 +19,21 @@ const compileContracts = sources => {
 
   // catch compiler errors
   if (errors) {
-    throw new Error(errors[0].message)
+    // Loop over each error to check of its type; error || warning
+    errors.map(item => {
+      // Regex condition
+      const warningRegex = new RegExp('Warning:')
+
+      // Check if the error item is just a warning
+      if (warningRegex.test(item)) {
+        console.info(
+          chalk.yellow(`⚠️  [WARNING] ⚠️: ${item.replace(/ Warning:/g, '')}`)
+        )
+      } else {
+        // return the error to console
+        console.error(chalk.red.bold(item))
+      }
+    })
   }
 
   // get `ABI` and `bytecode` from the compiled contract, keyed by contract name


### PR DESCRIPTION
- Handle compile warnings as warnings, rather than errors.
- Display all errors and warnings in console.